### PR TITLE
feat: parallelize single-load cache generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Note: The `--json` option can only be used with `--quiet`. If used without `--qu
 | `--init`         | Initial SQL commands (e.g., `CREATE TABLE`)         |
 | `--drop`         | Drop the table before starting (applies to target table only) |
 | `--delay`        | Delay in seconds between queries (default: 0)  |
+| `--cache-gen-workers` | Number of worker processes for cache generation (default: 1) |
 
 ### Advanced Patterns
 

--- a/manticore-load
+++ b/manticore-load
@@ -80,6 +80,26 @@ if ($shm_key === -1) {
     $shm_key = 0x742E; // Arbitrary but unique key
 }
 
+// Clean up stale shared memory and semaphore segments from previous runs
+function cleanupIpc($shm_key, $stop_shm_key, $sem_key) {
+    $keys = [$shm_key, $stop_shm_key];
+    foreach ($keys as $key) {
+        $shm = @shmop_open($key, "w", 0, 0);
+        if ($shm !== false) {
+            @shmop_delete($shm);
+            @shmop_close($shm);
+        }
+    }
+    $sem = @sem_get($sem_key, 1, 0644, 1);
+    if ($sem !== false) {
+        @sem_remove($sem);
+    }
+}
+
+$stop_shm_key = ftok(__FILE__, 'x');
+$sem_key = ftok(__FILE__, 's');
+cleanupIpc($shm_key, $stop_shm_key, $sem_key);
+
 // Calculate required bytes: 1 byte for total processes, then 2 bytes per process (1 for ready, 1 for start signal)
 $num_processes = count($processes);
 $shm_size = 1 + ($num_processes * 2);
@@ -95,7 +115,6 @@ if ($sem_id === false) {
     die("Failed to create semaphore\n");
 }
 
-$stop_shm_key = ftok(__FILE__, 'x');
 $stop_shm_id = shmop_open($stop_shm_key, "c", 0644, 1);  // 1 byte for stop flag
 if ($stop_shm_id === false) {
     die("Failed to create stop signal shared memory segment\n");
@@ -105,14 +124,44 @@ shmop_write($stop_shm_id, "\0", 0);
 
 // This function waits for an idle mysql connection for the $query, runs it and exits
 function process($query, &$all_links, &$requests, &$statistics, $delay) {
-    global $stop_shm_id;
+    global $stop_shm_id, $config;
+
+    $is_gone_away = function($e) {
+        $code = (int)$e->getCode();
+        if ($code === 2006 || $code === 2013) {
+            return true;
+        }
+        $msg = strtolower($e->getMessage());
+        return strpos($msg, 'server has gone away') !== false || strpos($msg, 'lost connection') !== false;
+    };
+
+    $reconnect = function($index) use (&$all_links, &$requests, $config) {
+        if (isset($all_links[$index]) && $all_links[$index]) {
+            @mysqli_close($all_links[$index]);
+        }
+        $link = @mysqli_connect($config->get('host'), '', '', '', $config->get('port'));
+        if (!$link) {
+            return false;
+        }
+        $all_links[$index] = $link;
+        $requests[$index] = null;
+        return true;
+    };
 
     try {
         // initialize all connections by sending first queries
         foreach ($all_links as $k=>$link) {
             if (@$requests[$k]) continue;
             $start_time = microtime(true);
-            mysqli_query($link, $query, MYSQLI_ASYNC);
+            try {
+                mysqli_query($link, $query, MYSQLI_ASYNC);
+            } catch (mysqli_sql_exception $e) {
+                if ($is_gone_away($e) && $reconnect($k)) {
+                    mysqli_query($all_links[$k], $query, MYSQLI_ASYNC);
+                } else {
+                    throw $e;
+                }
+            }
             // Store both query start time and delay end time
             @$requests[$k] = [
                 'start_time' => $start_time,
@@ -158,7 +207,15 @@ function process($query, &$all_links, &$requests, &$statistics, $delay) {
                 if (($requests[$i]['readiness'] & 3) === 3) {
                     $latency = $current_time - $requests[$i]['start_time'];
                     $statistics->addLatency($latency * 1000);
-                    mysqli_query($all_links[$i], $query, MYSQLI_ASYNC);
+                    try {
+                        mysqli_query($all_links[$i], $query, MYSQLI_ASYNC);
+                    } catch (mysqli_sql_exception $e) {
+                        if ($is_gone_away($e) && $reconnect($i)) {
+                            mysqli_query($all_links[$i], $query, MYSQLI_ASYNC);
+                        } else {
+                            throw $e;
+                        }
+                    }
                     $requests[$i] = [
                         'start_time' => $current_time,
                         'delay_until' => $current_time + $delay,

--- a/src/configuration.php
+++ b/src/configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ArrayAccess {
         'threads:',
         'total:',
         'iterations:',
+        'cache-gen-workers:',
         'verbose',
         'quiet',
         'json',
@@ -58,6 +59,7 @@ class Configuration implements ArrayAccess {
         'wait' => false,
         'no-color' => false,
         'latency-histograms' => true,
+        'cache-gen-workers' => 1,
         'delay' => 0
     ];
 
@@ -99,7 +101,7 @@ class Configuration implements ArrayAccess {
         $process_options = [];
         $per_process_params = [
             'drop', 'batch-size', 'threads', 'total', 
-            'iterations', 'init', 'load', 'load-distribution', 'column', 'delay'
+            'iterations', 'init', 'load', 'load-distribution', 'column', 'delay', 'cache-gen-workers'
         ];
         $index = 1;
         
@@ -236,7 +238,7 @@ class Configuration implements ArrayAccess {
                 $process['drop-table'] = true;
             }
             
-            foreach (['port', 'total', 'iterations'] as $key) {
+            foreach (['port', 'total', 'iterations', 'cache-gen-workers'] as $key) {
                 if (isset($process[$key])) {
                     $process[$key] = (int)$process[$key];
                 }
@@ -320,6 +322,10 @@ class Configuration implements ArrayAccess {
                 }
             }
 
+            if (isset($process['cache-gen-workers']) && $process['cache-gen-workers'] <= 0) {
+                die("ERROR: Parameter --cache-gen-workers must be a positive number for process " . $index . "\n");
+            }
+
             // Validate threads array
             if (isset($process['threads'])) {
                 foreach ($process['threads'] as $thread_count) {
@@ -400,6 +406,8 @@ class Configuration implements ArrayAccess {
             "  --latency-histograms=[0|1]   Use histogram-based latency tracking (default: 1)\n" .
             "                               1: memory-efficient but approximate percentiles\n" .
             "                               0: precise percentiles but higher memory usage\n" .
+            "  --cache-gen-workers=N        Number of worker processes for cache generation\n" .
+            "                               (default: 1)\n" .
             "  --delay=N                    Add artificial delay between queries in seconds (default: 0)\n" .
             "  --together                   Run multiple processes with different configurations.\n" .
             "                               Each section after --together can have its own process-specific\n" .


### PR DESCRIPTION
- added --cache-gen-workers config/usage and include it in cache key
- implemented forked cache workers with deterministic increment offsets
- added reconnect+retry on “server has gone away” during async query dispatch