### PR TITLE
feat: --cache-from-disk mode and OOM hint for large caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Note: The `--json` option can only be used with `--quiet`. If used without `--qu
 | `--drop`         | Drop the table before starting (applies to target table only) |
 | `--delay`        | Delay in seconds between queries (default: 0)  |
 | `--cache-gen-workers` | Number of worker processes for cache generation (default: 1) |
+| `--cache-from-disk` | Stream cache from disk instead of loading into memory |
 
 ### Advanced Patterns
 

--- a/manticore-load
+++ b/manticore-load
@@ -16,6 +16,21 @@ mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 // Memory limit setting
 ini_set('memory_limit', '8G');
 
+// Suggest streaming cache from disk on OOM in query generation
+register_shutdown_function(function () {
+    $error = error_get_last();
+    if (!$error || $error['type'] !== E_ERROR) {
+        return;
+    }
+    if (strpos($error['message'], 'Allowed memory size') === false) {
+        return;
+    }
+    if (strpos($error['message'], 'query_generator.php') === false) {
+        return;
+    }
+    fwrite(STDERR, "Hint: try --cache-from-disk to stream the cache instead of loading it into memory.\n");
+});
+
 // Enable signal handling
 declare(ticks = 1);
 
@@ -526,22 +541,28 @@ function run_process($process_config, $config, $process_index, $num_processes) {
     if ($config->get('verbose')) {
         echo "\nProcess $process_index prepared queries:\n";
         echo "--------------------------------------------------------------------------------\n";
-        foreach (array_slice($batches, 0, 3) as $query) {
+        $preview_queries = is_array($batches) ? array_slice($batches, 0, 3) : (method_exists($batches, 'preview') ? $batches->preview(3) : []);
+        foreach ($preview_queries as $query) {
             echo $query . "\n";
         }
-        if (count($batches) > 3) {
-            echo "... (" . (count($batches) - 3) . " more queries)\n";
+        $total_batches = count($batches);
+        if ($total_batches > 3) {
+            echo "... (" . ($total_batches - 3) . " more queries)\n";
         }
         echo "--------------------------------------------------------------------------------\n\n";
     }
 
     // Handle iterations
     if ($process_config['iterations'] > 1) {
-        $batchesMulti = [];
-        for ($n = 0; $n < $process_config['iterations']; $n++) {
-            $batchesMulti = array_merge($batchesMulti, $batches);
+        if (is_array($batches)) {
+            $batchesMulti = [];
+            for ($n = 0; $n < $process_config['iterations']; $n++) {
+                $batchesMulti = array_merge($batchesMulti, $batches);
+            }
+            $batches = $batchesMulti;
+        } else {
+            $batches = new RepeatingBatches($batches, $process_config['iterations']);
         }
-        $batches = $batchesMulti;
     }
 
     // Initialize components

--- a/src/configuration.php
+++ b/src/configuration.php
@@ -33,6 +33,7 @@ class Configuration implements ArrayAccess {
         'total:',
         'iterations:',
         'cache-gen-workers:',
+        'cache-from-disk',
         'verbose',
         'quiet',
         'json',
@@ -60,6 +61,7 @@ class Configuration implements ArrayAccess {
         'no-color' => false,
         'latency-histograms' => true,
         'cache-gen-workers' => 1,
+        'cache-from-disk' => false,
         'delay' => 0
     ];
 
@@ -101,7 +103,8 @@ class Configuration implements ArrayAccess {
         $process_options = [];
         $per_process_params = [
             'drop', 'batch-size', 'threads', 'total', 
-            'iterations', 'init', 'load', 'load-distribution', 'column', 'delay', 'cache-gen-workers'
+            'iterations', 'init', 'load', 'load-distribution', 'column', 'delay', 'cache-gen-workers',
+            'cache-from-disk'
         ];
         $index = 1;
         
@@ -408,6 +411,7 @@ class Configuration implements ArrayAccess {
             "                               0: precise percentiles but higher memory usage\n" .
             "  --cache-gen-workers=N        Number of worker processes for cache generation\n" .
             "                               (default: 1)\n" .
+            "  --cache-from-disk            Stream cache from disk instead of loading into memory\n" .
             "  --delay=N                    Add artificial delay between queries in seconds (default: 0)\n" .
             "  --together                   Run multiple processes with different configurations.\n" .
             "                               Each section after --together can have its own process-specific\n" .


### PR DESCRIPTION
- stream cached queries from disk with warm-up pre-read
- add --cache-from-disk CLI flag and docs
- support iterable batches for verbose previews and iterations
- warn when cache size likely exceeds memory before loading